### PR TITLE
allow content to be added to index and list pages

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,7 @@
 {{ define "main" }}
 
 <h1>{{ .Title }}</h1>
+{{ .Content }}
 {{ $pages := .Pages }}
 {{ range $pages.ByPublishDate.Reverse }}
   <h2 class="post-list {{ if ne .Params.show_summary false }}summary{{ end }}">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,7 @@
 {{ define "main" }}
 
 <h1>{{ .Title }}</h1>
+{{ .Content }}
 {{ $pages := where site.RegularPages "Type" "in" site.Params.mainSections }}
 {{ range $pages.ByPublishDate.Reverse }}
   <h2 class="post-list {{ if ne .Params.show_summary false }}summary{{ end }}">
@@ -11,5 +12,5 @@
   {{ if ne .Params.show_summary false }}
     {{ .Summary }}
   {{ end }}
-{{ end }}  
+{{ end }}
 {{ end }}


### PR DESCRIPTION
It's a small, non-breaking change that simply embeds ``{{ .Content }}`` in the list and index templates.