### PR TITLE
Adds inbuilt Social/SEO templates

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,9 +7,7 @@
   <link rel="canonical" href="{{ .Permalink }}">
 
   {{ if .IsHome }}
-    {{ with .Site.Params.homeMetaContent }}
-      <meta name="description" content="{{ . | plainify }}">
-    {{ end }}
+      <meta name="description" content="{{ default .Site.Params.Description .Site.Params.homeMetaContent | plainify }}">
   {{ end }}
 
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,4 +31,7 @@
     {{ $title = .Site.Title }}
   {{ end }}
   <title>{{ $title }}</title>
+	{{ template "_internal/twitter_cards.html" . }}
+	{{ template "_internal/opengraph.html" . }}
+	{{ template "_internal/schema.html" . }}
 </head>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,9 +5,10 @@
 
   {{ hugo.Generator }}
   <link rel="canonical" href="{{ .Permalink }}">
-
   {{ if .IsHome }}
       <meta name="description" content="{{ default .Site.Params.Description .Site.Params.homeMetaContent | plainify }}">
+	{{ else }}
+      <meta name="description" content="{{ .Description | plainify }}">
   {{ end }}
 
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">


### PR DESCRIPTION
I thought it's a good idea to have nice looking share links.
This patch also allows to omit the ``homeMetaDescription`` and use ``params.description`` instead.
Also adds the ``.Description`` on each page.