### PR TITLE
Support Disqus

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -4,6 +4,11 @@ defaultContentLanguage = "en"
 title = "PaperCSS"
 theme = "papercss-hugo-theme"
 googleAnalytics = "UA-123456789-1"
+disqusShortname = "yourdiscussshortname"
+
+[privacy]
+  [privacy.disqus]
+    disable = true
 
 [taxonomies]
   tag = "tags"

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -4,6 +4,11 @@ defaultContentLanguage: en
 title: PaperCSS
 theme: papercss-hugo-theme
 googleAnalytics: UA-123456789-1
+disqusShortname: yourdiscussshortname
+
+privacy:
+  disqus:
+    disable: true
 
 taxonomies:
   tag: tags

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -17,5 +17,6 @@
 {{ end }}
 
 {{ .Content }}
-  
+{{ template "_internal/disqus.html" . }}
+
 {{ end }}


### PR DESCRIPTION
This PR imports the internal template of Hugo to support Disqus.

( https://gohugo.io/content-management/comments/ )

After applying Disqus, the page appears as follows.

![image](https://user-images.githubusercontent.com/910151/87486099-6bc88c80-c675-11ea-8d79-4c6cd70baca2.png)
